### PR TITLE
capture singletons in ExtendedCCDBG::traverse()

### DIFF
--- a/src/ColoredDeBruijnGraph.h
+++ b/src/ColoredDeBruijnGraph.h
@@ -107,7 +107,7 @@ private:
     void reset_dfs_states();
 
 
-    bool is_startnode(const UnitigColorMap<UnitigExtension> &ucm);
+    bool is_startnode(const UnitigColorMap<UnitigExtension> &ucm) const;
 
 
     /**         Get a ranking of the neighbors.


### PR DESCRIPTION
Missing singletons was a major problem. It's now fixed within the CCDBG traversal as option if no neighbors where found on a valid start node.