### PR TITLE
Add CI for Linux AMD64/ARM64 based on Github Actions

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -xe
+
+rm -rf bifrost bwa htslib samtools sickle
+
+BIN_FOLDER=$(mktemp -d)
+PATH=$BIN_FOLDER:$PATH
+NPROC=$(nproc)
+ARCH=$(echo $(uname -m) | tr '_' '-')
+
+# Bifrost
+git clone --recursive https://github.com/pmelsted/bifrost.git
+pushd bifrost
+mkdir build && cd build
+cmake ..
+make -j$NPROC
+sudo make install
+file /usr/local/bin/Bifrost | grep $ARCH
+popd
+
+# Bwa
+git clone --recursive https://github.com/lh3/bwa.git
+pushd bwa
+make -j$NPROC
+cp bwa $BIN_FOLDER/
+file $BIN_FOLDER/bwa | grep $ARCH
+popd
+
+# Samtools
+## Htslib
+git clone --recursive https://github.com/samtools/htslib.git
+pushd htslib
+autoreconf -i
+./configure
+make -j$NPROC
+popd
+
+## Samtools
+git clone --recursive https://github.com/samtools/samtools.git
+pushd samtools
+make -j$NPROC
+cp samtools $BIN_FOLDER/
+file $BIN_FOLDER/samtools | grep $ARCH
+popd
+
+# Sickle
+git clone --recursive https://github.com/najoshi/sickle.git
+pushd sickle
+make -j$NPROC
+cp sickle $BIN_FOLDER/
+file $BIN_FOLDER/sickle | grep $ARCH
+popd
+
+# PopIns2
+git config --global --add safe.directory .
+mkdir -p build
+make -j$NPROC
+file popins2 | grep $ARCH

--- a/.github/build.sh
+++ b/.github/build.sh
@@ -2,8 +2,6 @@
 
 set -xe
 
-rm -rf bifrost bwa htslib samtools sickle
-
 BIN_FOLDER=$(mktemp -d)
 PATH=$BIN_FOLDER:$PATH
 NPROC=$(nproc)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-x86_64:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      run: .github/build.sh
+
+  build-aarch64:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      uses: uraimo/run-on-arch-action@v2
+      with:
+        arch: aarch64
+        distro: ubuntu20.04
+        githubToken: ${{ github.token }}
+        dockerRunArgs: |
+          --volume "${PWD}:/PopIns2"
+        install: |
+          apt-get update -q -y
+          apt-get install -q -y build-essential autoconf git cmake file zlib1g-dev ncurses-dev sudo libbz2-dev liblzma-dev
+        run: |
+          pushd /PopIns2
+          .github/build.sh


### PR DESCRIPTION
Adds `.github/workflows/ci.yaml` - a config file for Github Actions CI.
It runs `.github/build.sh` on Ubuntu 20.04 for x86_64 and aarch64.